### PR TITLE
Fix for leftover test images that got created but not properly cleaned up

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,7 +27,9 @@ module.exports = tseslint.config(
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {
-        projectService: true,
+        projectService: {
+          allowDefaultProject: ['src/generators/social/__tests__/*.ts'],
+        },
         tsconfigRootDir: __dirname,
       },
     },

--- a/src/generators/social/base-opengraph.ts
+++ b/src/generators/social/base-opengraph.ts
@@ -64,21 +64,30 @@ export class BaseOpenGraphGenerator {
     const outputPath = path.join(this.config.output.path, filename);
 
     const processor = new ImageProcessor(this.sourceImage);
-    const socialFile = await processor.createSocialPreview({
-      width: width || ImageSizes.social.standard.width,
-      height: height || ImageSizes.social.standard.height,
-      title, // Only add text if explicitly provided
-      description, // Only add text if explicitly provided
-      template,
-      background: this.config.backgroundColor
-    });
+    let finalProcessor: ImageProcessor | undefined;
     
-    const finalProcessor = new ImageProcessor(socialFile);
-    await finalProcessor.save(outputPath, {
-      format: 'png',
-      quality: this.config.output.quality
-    });
-    await processor.cleanup();
+    try {
+      const socialFile = await processor.createSocialPreview({
+        width: width || ImageSizes.social.standard.width,
+        height: height || ImageSizes.social.standard.height,
+        title, // Only add text if explicitly provided
+        description, // Only add text if explicitly provided
+        template,
+        background: this.config.backgroundColor
+      });
+      
+      finalProcessor = new ImageProcessor(socialFile);
+      await finalProcessor.save(outputPath, {
+        format: 'png',
+        quality: this.config.output.quality
+      });
+    } finally {
+      // Clean up all temporary files from both processors
+      await processor.cleanup();
+      if (finalProcessor) {
+        await finalProcessor.cleanup();
+      }
+    }
   }
 
   /**

--- a/src/generators/social/messaging.ts
+++ b/src/generators/social/messaging.ts
@@ -103,6 +103,8 @@ export class MessagingGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -129,6 +131,7 @@ export class MessagingGenerator {
       quality: this.config.output.quality
     });
     await squareProcessor.cleanup();
+    await squareFinal.cleanup();
 
     // Link preview format
     const { width: linkWidth, height: linkHeight } = ImageSizes.messaging.whatsappLink;
@@ -150,6 +153,7 @@ export class MessagingGenerator {
       quality: this.config.output.quality
     });
     await linkProcessor.cleanup();
+    await linkFinal.cleanup();
   }
 
   /**
@@ -175,6 +179,7 @@ export class MessagingGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -200,6 +205,7 @@ export class MessagingGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -225,6 +231,7 @@ export class MessagingGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -250,6 +257,7 @@ export class MessagingGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -275,6 +283,7 @@ export class MessagingGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -300,6 +309,7 @@ export class MessagingGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -324,6 +334,7 @@ export class MessagingGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**

--- a/src/generators/social/opengraph.ts
+++ b/src/generators/social/opengraph.ts
@@ -23,17 +23,22 @@ export class OpenGraphGenerator {
    * Generate OpenGraph images for various platforms
    */
   async generate(): Promise<void> {
-    const { socialPreview } = this.config;
-    const options = socialPreview || {};
+    try {
+      const { socialPreview } = this.config;
+      const options = socialPreview || {};
 
-    // Generate Facebook/Default OpenGraph Image
-    await this.generateFacebookImage(options);
+      // Generate Facebook/Default OpenGraph Image
+      await this.generateFacebookImage(options);
 
-    // Generate LinkedIn Image
-    await this.generateLinkedInImage(options);
+      // Generate LinkedIn Image
+      await this.generateLinkedInImage(options);
 
-    // Generate Twitter Card Image
-    await this.generateTwitterImage(options);
+      // Generate Twitter Card Image
+      await this.generateTwitterImage(options);
+    } finally {
+      // Clean up all temporary files
+      await this.processor.cleanup();
+    }
   }
 
   /**

--- a/src/generators/social/platforms.ts
+++ b/src/generators/social/platforms.ts
@@ -96,6 +96,7 @@ export class PlatformGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -120,6 +121,7 @@ export class PlatformGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -144,6 +146,7 @@ export class PlatformGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -168,6 +171,7 @@ export class PlatformGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -192,6 +196,7 @@ export class PlatformGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -216,6 +221,7 @@ export class PlatformGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -240,6 +246,7 @@ export class PlatformGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -264,6 +271,7 @@ export class PlatformGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**
@@ -288,6 +296,7 @@ export class PlatformGenerator {
       quality: this.config.output.quality
     });
     await processor.cleanup();
+    await finalProcessor.cleanup();
   }
 
   /**

--- a/src/generators/social/whatsapp.ts
+++ b/src/generators/social/whatsapp.ts
@@ -66,20 +66,28 @@ export class WhatsAppGenerator {
    */
   private async generateLinkPreviewImage(title?: string, description?: string, template?: 'basic' | 'gradient' | 'custom'): Promise<void> {
     const processor = new ImageProcessor(this.sourceImage);
-    const outputPath = path.join(this.config.output.path, 'whatsapp-link.png');
-
-    const socialFile = await processor.createSocialPreview({
-      width: ImageSizes.messaging.whatsappLink.width,
-      height: ImageSizes.messaging.whatsappLink.height,
-      title,
-      description,
-      template,
-      background: this.config.backgroundColor
-    });
+    let finalProcessor: ImageProcessor | undefined;
     
-    const finalProcessor = new ImageProcessor(socialFile);
-    await finalProcessor.save(outputPath);
-    await processor.cleanup();
+    try {
+      const outputPath = path.join(this.config.output.path, 'whatsapp-link.png');
+
+      const socialFile = await processor.createSocialPreview({
+        width: ImageSizes.messaging.whatsappLink.width,
+        height: ImageSizes.messaging.whatsappLink.height,
+        title,
+        description,
+        template,
+        background: this.config.backgroundColor
+      });
+      
+      finalProcessor = new ImageProcessor(socialFile);
+      await finalProcessor.save(outputPath);
+    } finally {
+      await processor.cleanup();
+      if (finalProcessor) {
+        await finalProcessor.cleanup();
+      }
+    }
   }
 
   /**
@@ -87,20 +95,28 @@ export class WhatsAppGenerator {
    */
   private async generateStandardImage(title?: string, description?: string, template?: 'basic' | 'gradient' | 'custom'): Promise<void> {
     const processor = new ImageProcessor(this.sourceImage);
-    const outputPath = path.join(this.config.output.path, 'whatsapp-share.png');
-
-         const socialFile = await processor.createSocialPreview({
-       width: ImageSizes.messaging.whatsappLink.width,
-       height: ImageSizes.messaging.whatsappLink.height,
-       title,
-       description,
-       template,
-       background: this.config.backgroundColor
-     });
+    let finalProcessor: ImageProcessor | undefined;
     
-    const finalProcessor = new ImageProcessor(socialFile);
-    await finalProcessor.save(outputPath);
-    await processor.cleanup();
+    try {
+      const outputPath = path.join(this.config.output.path, 'whatsapp-share.png');
+
+      const socialFile = await processor.createSocialPreview({
+        width: ImageSizes.messaging.whatsappLink.width,
+        height: ImageSizes.messaging.whatsappLink.height,
+        title,
+        description,
+        template,
+        background: this.config.backgroundColor
+      });
+      
+      finalProcessor = new ImageProcessor(socialFile);
+      await finalProcessor.save(outputPath);
+    } finally {
+      await processor.cleanup();
+      if (finalProcessor) {
+        await finalProcessor.cleanup();
+      }
+    }
   }
 
   /**
@@ -108,20 +124,28 @@ export class WhatsAppGenerator {
    */
   private async generateSquareImage(title?: string, description?: string, template?: 'basic' | 'gradient' | 'custom'): Promise<void> {
     const processor = new ImageProcessor(this.sourceImage);
-    const outputPath = path.join(this.config.output.path, 'whatsapp-square.png');
-
-    const socialFile = await processor.createSocialPreview({
-      width: 1200,
-      height: 1200,
-      title,
-      description,
-      template,
-      background: this.config.backgroundColor
-    });
+    let finalProcessor: ImageProcessor | undefined;
     
-    const finalProcessor = new ImageProcessor(socialFile);
-    await finalProcessor.save(outputPath);
-    await processor.cleanup();
+    try {
+      const outputPath = path.join(this.config.output.path, 'whatsapp-square.png');
+
+      const socialFile = await processor.createSocialPreview({
+        width: 1200,
+        height: 1200,
+        title,
+        description,
+        template,
+        background: this.config.backgroundColor
+      });
+      
+      finalProcessor = new ImageProcessor(socialFile);
+      await finalProcessor.save(outputPath);
+    } finally {
+      await processor.cleanup();
+      if (finalProcessor) {
+        await finalProcessor.cleanup();
+      }
+    }
   }
 
   /**

--- a/src/generators/web/seo.ts
+++ b/src/generators/web/seo.ts
@@ -114,19 +114,27 @@ export class WebSEOGenerator {
       background: this.config.backgroundColor
     });
 
-    // Save in requested format(s)
-    if (outputFormat === 'png' || outputFormat === 'both') {
-      const outputPath = path.join(this.config.output.path, 'opengraph.png');
-      const final1 = new ImageProcessor(socialFile);
-      await final1.save(outputPath, { format: 'png', quality: this.config.output.quality });
-    }
+    const processors: ImageProcessor[] = [processor];
 
-    if (outputFormat === 'jpeg' || outputFormat === 'both') {
-      const outputPath = path.join(this.config.output.path, 'opengraph.jpg');
-      const final2 = new ImageProcessor(socialFile);
-      await final2.save(outputPath, { format: 'jpeg', quality: this.config.output.quality });
+    try {
+      // Save in requested format(s)
+      if (outputFormat === 'png' || outputFormat === 'both') {
+        const outputPath = path.join(this.config.output.path, 'opengraph.png');
+        const final1 = new ImageProcessor(socialFile);
+        processors.push(final1);
+        await final1.save(outputPath, { format: 'png', quality: this.config.output.quality });
+      }
+
+      if (outputFormat === 'jpeg' || outputFormat === 'both') {
+        const outputPath = path.join(this.config.output.path, 'opengraph.jpg');
+        const final2 = new ImageProcessor(socialFile);
+        processors.push(final2);
+        await final2.save(outputPath, { format: 'jpeg', quality: this.config.output.quality });
+      }
+    } finally {
+      // Clean up all processors
+      await Promise.all(processors.map(p => p.cleanup()));
     }
-    await processor.cleanup();
   }
 
   /**


### PR DESCRIPTION
The cleanup logic was missing for all the new website opengraph images we created.